### PR TITLE
feat(ProductCard): モバイル時のスクロールトリガーを追加

### DIFF
--- a/src/app/products/page.tsx
+++ b/src/app/products/page.tsx
@@ -14,13 +14,13 @@ import type { Product } from "@/lib/products-data";
 export default function ProductsPage() {
   const [selectedProduct, setSelectedProduct] = useState<Product | null>(null);
 
-  const [animatedCardId, setAnimatedCardId] = useState<string | null>(null);
+  const [animatedCardId, setAnimatedCardId] = useState<string | number | null>(null);
 
-  const handleCardInView = (id: string) => {
+  const handleCardInView = (id: string | number) => {
     setAnimatedCardId(id);
   };
 
-  const handleCardOutOfView = (id: string) => {
+  const handleCardOutOfView = (id: string | number) => {
     if (animatedCardId === id) {
       setAnimatedCardId(null);
     }

--- a/src/app/products/page.tsx
+++ b/src/app/products/page.tsx
@@ -14,6 +14,18 @@ import type { Product } from "@/lib/products-data";
 export default function ProductsPage() {
   const [selectedProduct, setSelectedProduct] = useState<Product | null>(null);
 
+  const [animatedCardId, setAnimatedCardId] = useState<string | null>(null);
+
+  const handleCardInView = (id: string) => {
+    setAnimatedCardId(id);
+  };
+
+  const handleCardOutOfView = (id: string) => {
+    if (animatedCardId === id) {
+      setAnimatedCardId(null);
+    }
+  };
+
   return (
     <main>
       <MobileMenu />
@@ -47,7 +59,13 @@ export default function ProductsPage() {
                 onClick={() => setSelectedProduct(product)}
                 className="cursor-pointer"
               >
-                <ProductCard product={product} />
+                <ProductCard
+                  product={product}
+                  onCardClick={() => setSelectedProduct(product)}
+                  isAnimated={animatedCardId === product.title}
+                  onInView={() => handleCardInView(product.title)}
+                  onOutOfView={() => handleCardOutOfView(product.title)}
+                />
               </div>
             ))}
           </div>

--- a/src/components/ProductCard.tsx
+++ b/src/components/ProductCard.tsx
@@ -1,11 +1,17 @@
 "use client";
 
 import Image from "next/image";
-import { motion } from "framer-motion";
+import { motion, useInView } from "framer-motion";
+import { useRef, useEffect } from "react";
 import type { Product } from "@/lib/products-data";
+import { useMediaQuery } from "@/hooks/useMediaQuery";
 
 type ProductCardProps = {
   product: Product;
+  onCardClick: (product: Product) => void;
+  isAnimated: boolean;
+  onInView: () => void;
+  onOutOfView: () => void;
 };
 
 const fillVariants = {
@@ -23,13 +29,32 @@ const textVariants = {
   hover: { color: "#0D1117" },
 };
 
-const ProductCard = ({ product }: ProductCardProps) => {
+const ProductCard = ({ product, onCardClick, isAnimated, onInView, onOutOfView  }: ProductCardProps) => {
+  const ref = useRef(null);
+  const isMobile = useMediaQuery("(max-width: 767px)");
+  const isInView = useInView(ref, { 
+    margin: "0px 0px -50% 0px",
+    once: false
+  });
+
+  useEffect(() => {
+    if (isMobile) {
+      if (isInView) {
+        onInView();
+      } else {
+        onOutOfView();
+      }
+    }
+  }, [isMobile, isInView, onInView, onOutOfView]);
+
   return (
     <motion.div
+      ref={ref}
       className="relative flex flex-col gap-4 rounded-lg bg-card p-4 shadow-lg"
       initial="rest"
-      whileHover="hover"
-      animate="rest"
+      onClick={() => onCardClick(product)}
+      whileHover={!isMobile ? "hover" : undefined}
+      animate={isMobile && isAnimated ? "hover" : "rest"}
     >
       
       <motion.div
@@ -56,7 +81,7 @@ const ProductCard = ({ product }: ProductCardProps) => {
 
         {/* テキストエリア */}
         <div>
-          <p className="text-xs text-gray-400">{product.team}</p>
+          <p className="text-xs text-gray-600">{product.team}</p>
           <motion.h3
             className="mt-1 font-bold text-3xl"
             variants={textVariants}

--- a/src/components/ProductCard.tsx
+++ b/src/components/ProductCard.tsx
@@ -29,7 +29,7 @@ const textVariants = {
   hover: { color: "#0D1117" },
 };
 
-const ProductCard = ({ product, onCardClick, isAnimated, onInView, onOutOfView  }: ProductCardProps) => {
+const ProductCard = ({ product, onCardClick, isAnimated, onInView, onOutOfView }: ProductCardProps) => {
   const ref = useRef(null);
   const isMobile = useMediaQuery("(max-width: 767px)");
   const isInView = useInView(ref, { 


### PR DESCRIPTION
概要 📝

モバイル表示のとき、スクロールに合わせてプロダクトカードがアニメーションするようにしました。
ユーザー体験の向上を目的としています。

変更点 ✨
モバイル (md幅以下):
スクロールして画面に入ってきたカードが1枚だけハイライトされます。
画面からカードが外れると、ハイライトは元に戻ります。
PC (md幅以上):
これまで通り、マウスカーソルを乗せるとアニメーションします。

Close #21