### PR TITLE
[performance]: トップページのLCP改善のため画像読込とフォントweightを最適化

### DIFF
--- a/src/app/ui/fonts.ts
+++ b/src/app/ui/fonts.ts
@@ -1,15 +1,21 @@
-import { Noto_Sans_JP, Oswald } from 'next/font/google';
+import { Noto_Sans_JP, Oswald } from "next/font/google";
 
 export const notoSansJP = Noto_Sans_JP({
-  subsets: ['latin'],
-  weight: ['400', '700'],
-  display: 'swap',
-  variable: '--font-noto-sans-jp',
+  subsets: ["latin"],
+  weight: ["400"],
+  display: "swap",
+  variable: "--font-noto-sans-jp",
+});
+
+export const notoSansJPBold = Noto_Sans_JP({
+  subsets: ["latin"],
+  weight: ["700"],
+  display: "swap",
 });
 
 export const oswald = Oswald({
-  subsets: ['latin'],
-  weight: ['500', '700'],
-  display: 'swap',
-  variable: '--font-oswald',
+  subsets: ["latin"],
+  weight: ["500", "700"],
+  display: "swap",
+  variable: "--font-oswald",
 });

--- a/src/components/LeftPanel.tsx
+++ b/src/components/LeftPanel.tsx
@@ -44,7 +44,6 @@ const LeftPanel = () => {
             height={1698}
             className="absolute bottom-0 left-1/2 h-auto w-auto max-h-[600px] -translate-x-[40%] translate-y-[35%] filter brightness-60"
             priority
-            fetchPriority="high"
             sizes="(max-width: 768px) 100vw, 50vw"
           />
         </div>

--- a/src/components/LeftPanel.tsx
+++ b/src/components/LeftPanel.tsx
@@ -24,7 +24,7 @@ const LeftPanel = () => {
                 />
               </div>
             </div>
-            
+
             <p className="font-en mt-0 md:mt-2 text-sm tracking-wider">
               Frontend Engineer
             </p>
@@ -44,6 +44,8 @@ const LeftPanel = () => {
             height={1698}
             className="absolute bottom-0 left-1/2 h-auto w-auto max-h-[600px] -translate-x-[40%] translate-y-[35%] filter brightness-60"
             priority
+            fetchPriority="high"
+            sizes="(max-width: 768px) 100vw, 50vw"
           />
         </div>
       </div>

--- a/src/components/ProductCard.tsx
+++ b/src/components/ProductCard.tsx
@@ -5,6 +5,7 @@ import { motion, useInView } from "framer-motion";
 import { useRef, useEffect } from "react";
 import type { Product } from "@/lib/products-data";
 import { useMediaQuery } from "@/hooks/useMediaQuery";
+import { notoSansJPBold } from "@/app/ui/fonts";
 
 type ProductCardProps = {
   product: Product;
@@ -32,7 +33,7 @@ const textVariants = {
 const ProductCard = ({ product, onCardClick, isAnimated, onInView, onOutOfView }: ProductCardProps) => {
   const ref = useRef(null);
   const isMobile = useMediaQuery("(max-width: 767px)");
-  const isInView = useInView(ref, { 
+  const isInView = useInView(ref, {
     margin: "0px 0px -50% 0px",
     once: false
   });
@@ -56,7 +57,7 @@ const ProductCard = ({ product, onCardClick, isAnimated, onInView, onOutOfView }
       whileHover={!isMobile ? "hover" : undefined}
       animate={isMobile && isAnimated ? "hover" : "rest"}
     >
-      
+
       <motion.div
         className="absolute inset-0 z-0 rounded-lg bg-foreground"
         variants={fillVariants}
@@ -83,7 +84,7 @@ const ProductCard = ({ product, onCardClick, isAnimated, onInView, onOutOfView }
         <div>
           <p className="text-xs text-gray-600">{product.team}</p>
           <motion.h3
-            className="mt-1 font-bold text-3xl"
+            className={`${notoSansJPBold.className} mt-1 text-3xl`}
             variants={textVariants}
             transition={{ duration: 0.2 }}
           >

--- a/src/components/ProductModal.tsx
+++ b/src/components/ProductModal.tsx
@@ -5,6 +5,7 @@ import { ExternalLink, Github, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { motion, AnimatePresence } from "framer-motion";
 import Image from "next/image";
+import { notoSansJPBold } from "@/app/ui/fonts";
 
 type ProductModalProps = {
   product: Product | null;
@@ -14,7 +15,9 @@ type ProductModalProps = {
 // ヘルパーコンポーネント: 各セクションのタイトルと内容を整形
 const Section = ({ title, children }: { title: string; children: React.ReactNode }) => (
   <div className="mb-8">
-    <h3 className="font-bold text-lg mb-3 border-b border-gray-700 pb-2">{title}</h3>
+    <h3 className={`${notoSansJPBold.className} text-lg mb-3 border-b border-gray-700 pb-2`}>
+      {title}
+    </h3>
     {children}
   </div>
 );
@@ -52,9 +55,10 @@ const ProductModal = ({ product, onClose }: ProductModalProps) => {
               {/* --- モーダルコンテンツ --- */}
               <div className="flex-1 overflow-y-auto p-8 scrollbar-hide">
                 {/* 1. タイトルを一番上に配置 */}
-                <h2 className="font-en text-4xl font-bold text-left mb-2">{product.title}</h2>
+                <h2 className={`${notoSansJPBold.className} text-4xl text-left mb-2`}>
+                  {product.title}
+                </h2>
                 <p className="text-sm text-md mb-2">{product.team} | {product.details.developmentPeriod}</p>
-                
                 <div className="flex gap-4 items-center mb-4">
                   {product.details.liveUrl && (
                     <a href={product.details.liveUrl} target="_blank" rel="noopener noreferrer" className="text-sm text-gray-400 hover:text-white transition-colors flex items-center gap-1">

--- a/src/components/ProductsSection.tsx
+++ b/src/components/ProductsSection.tsx
@@ -26,11 +26,12 @@ const ProductsSection = () => {
             alt="Macbook portfolio"
             width={1500}
             height={1126}
+            sizes="(max-width: 767px) 60vw, 25vw"
             className="transition-all duration-300 ease-in-out hover:scale-110 hover:-rotate-3 hover:opacity-100 opacity-70"
           />
         </div>
 
-        <div 
+        <div
           className="absolute top-1/2 left-1/2 w-[30%] -translate-x-[-50%] -translate-y-[100%] cursor-pointer md:w-[20%] md:-translate-x-[-90%] md:-translate-y-[110%]"
           onClick={() => notepiaData && setSelectedProduct(notepiaData)}
         >
@@ -39,6 +40,7 @@ const ProductsSection = () => {
             alt="iPhone portfolio"
             width={549}
             height={725}
+            sizes="(max-width: 767px) 30vw, 10vw"
             className="transition-all duration-300 ease-in-out hover:scale-110 hover:rotate-3 hover:opacity-100 opacity-70"
           />
         </div>

--- a/src/components/ProfileContent.tsx
+++ b/src/components/ProfileContent.tsx
@@ -5,6 +5,7 @@ import Image from "next/image";
 import { aboutData, biographyData, techStackData, likesData } from "@/lib/profile-data";
 import { motion, AnimatePresence } from "framer-motion";
 import { ChevronDown } from "lucide-react";
+import { notoSansJPBold } from "@/app/ui/fonts";
 
 // セクション全体を囲むコンポーネント
 const Section = ({
@@ -81,7 +82,9 @@ const ProfileContent = () => {
           <Image src={aboutData.imageSrc} alt={aboutData.name} fill className="object-cover" />
         </div>
         <div className="col-span-1 lg:col-span-2 text-left">
-          <h3 className="text-2xl font-bold text-primary mb-2">{aboutData.name}</h3>
+          <h3 className={`${notoSansJPBold.className} text-2xl text-primary mb-2`}>
+            {aboutData.name}
+          </h3>
           <p className="leading-relaxed text-gray-300">{aboutData.bio}</p>
         </div>
       </section>
@@ -94,9 +97,9 @@ const ProfileContent = () => {
       >
         <div className="flex flex-col gap-y-6">
           {biographyData.map((item) => (
-            <BiographyItem 
+            <BiographyItem
             key={`${item.year}-${item.event.slice(0, 20)}`}
-            year={item.year} 
+            year={item.year}
             event={item.event} />
           ))}
         </div>
@@ -129,7 +132,9 @@ const ProfileContent = () => {
             <div key={like.title} className="flex items-center gap-x-4">
               <div className="flex-shrink-0 w-24 h-24 md:w-32 md:h-32 flex items-center justify-center">{like.icon}</div>
               <div>
-                <h4 className="font-bold text-primary">{like.title}</h4>
+                <h4 className={`${notoSansJPBold.className} text-primary`}>
+                  {like.title}
+                </h4>
                 <p className="text-sm text-gray-300 mt-1">{like.description}</p>
               </div>
             </div>


### PR DESCRIPTION
## 概要
トップページのLCP改善を目的として、初期描画コストの見直しを実施。

## 対応内容
- LeftPanel.tsxのLCP画像に `fetchPriority` / `sizes` を追加
- `Noto Sans JP` のグローバル読み込み weight を `400` のみに削減
- 太字が必要な箇所のみ `Noto Sans JP 700` を局所適用
  - ProductModal.tsx
  - ProductCard.tsx
  - ProfileContent.tsx

## A/Bテストで検証したが主因ではなかったもの
- LoadingScreenの無効化
- `mono-sora.png` の除外
- `brightness-60` の除外
- LeftPanel.tsxの簡略化
- `tw-animate-css` の除外
- ProductModal.tsxのdynamic import

## 結果
Lighthouse (Mobile) にて以下の改善を確認
- 改善前: Performance 73 / FCP 3.3s / LCP 5.3s
- 改善後: Performance 80 / FCP 2.6s / LCP 4.6s

## 補足
今回の検証から、トップページのLCP悪化要因として、
画像通信そのものよりも、初期描画時に不要なフォント weight をグローバルに持っていたことが悪化要因の1つであると考えた。

残課題として、render-blocking CSS / unused CSS / unused JS の整理余地がありますが、こちらは別PR・別issueで対応予定。

close #29 